### PR TITLE
Add missing step in React intro

### DIFF
--- a/react/react_intro/README.md
+++ b/react/react_intro/README.md
@@ -307,7 +307,7 @@ const Feed = () => {
 export default Feed;
 ```
 
-Returning to your browser, you should see the following image:
+*Exercise: Add the `<Feed />` component to `<App />`, above the contacts list. Returning to your browser, you should see the following image:*
 
 ![feedImgNoCSS](./images/feedImgNoCSS.png)
 


### PR DESCRIPTION
There is a small step missing in the intro. After we have created the `<Feed />` component, it needs to be added to the app in order to render it in the browser. Rather than spelling out that step and the code, I propose making that an exercise.